### PR TITLE
Handle exceptions which can make GetServerRules to fail.

### DIFF
--- a/Src/SampQuery.cs
+++ b/Src/SampQuery.cs
@@ -387,7 +387,7 @@ namespace SAMPQuery
                         if (property != null)
                         {
                             if (property.PropertyType == typeof(bool)) val = value == "On";
-                            else if (property.PropertyType == typeof(Uri)) val = TryParseUri(value) ?? new Uri("http://sa-mp.com/", UriKind.Absolute);
+                            else if (property.PropertyType == typeof(Uri)) val = Helpers.TryParseWeburl(value);
                             else if (property.PropertyType == typeof(DateTime))
                             {
                                 bool success = TimeSpan.TryParse(value, out TimeSpan parsedTime);
@@ -403,24 +403,6 @@ namespace SAMPQuery
                         }
                     }
                     return sampServerRulesData;
-                }
-            }
-        }
-
-        private static Uri TryParseUri(string value) {
-            try
-            {
-                return new Uri("http://" + value, UriKind.Absolute);
-            }
-            catch
-            {
-                try
-                {
-                    return new Uri(value, UriKind.Absolute);
-                }
-                catch
-                {
-                    return null;
                 }
             }
         }

--- a/Src/SampQuery.cs
+++ b/Src/SampQuery.cs
@@ -387,7 +387,16 @@ namespace SAMPQuery
                         if (property != null)
                         {
                             if (property.PropertyType == typeof(bool)) val = value == "On";
-                            else if (property.PropertyType == typeof(Uri)) val = Helpers.TryParseWeburl(value);
+                            else if (property.PropertyType == typeof(Uri))
+                            {
+                                bool success = Uri.TryCreate(value, UriKind.Absolute, out Uri parsedUri);
+                                if (!success) 
+                                    success = Uri.TryCreate("http://" + value, UriKind.Absolute, out parsedUri);
+                                if (!success) 
+                                    parsedUri = new Uri("http://sa-mp.com/", UriKind.Absolute);
+
+                                val = parsedUri;
+                            }
                             else if (property.PropertyType == typeof(DateTime))
                             {
                                 bool success = TimeSpan.TryParse(value, out TimeSpan parsedTime);

--- a/Src/SampQuery.cs
+++ b/Src/SampQuery.cs
@@ -387,19 +387,15 @@ namespace SAMPQuery
                         if (property != null)
                         {
                             if (property.PropertyType == typeof(bool)) val = value == "On";
-                            else if (property.PropertyType == typeof(Uri)) val = new Uri("http://" + value, UriKind.Absolute);
+                            else if (property.PropertyType == typeof(Uri)) val = TryParseUri(value) ?? new Uri("http://sa-mp.com/", UriKind.Absolute);
                             else if (property.PropertyType == typeof(DateTime))
                             {
-                                TimeSpan substracT;
-                                try
+                                bool success = TimeSpan.TryParse(value, out TimeSpan parsedTime);
+                                if (!success)
                                 {
-                                    substracT = TimeSpan.Parse(value);
+                                    parsedTime = TimeSpan.FromHours(0);
                                 }
-                                catch
-                                {
-                                    substracT = TimeSpan.FromHours(0);
-                                }
-                                val = DateTime.Today.Add(substracT);
+                                val = DateTime.Today.Add(parsedTime);
                             }
                             else val = Convert.ChangeType(value, property.PropertyType, CultureInfo.InvariantCulture);
 
@@ -407,6 +403,24 @@ namespace SAMPQuery
                         }
                     }
                     return sampServerRulesData;
+                }
+            }
+        }
+
+        private static Uri TryParseUri(string value) {
+            try
+            {
+                return new Uri("http://" + value, UriKind.Absolute);
+            }
+            catch
+            {
+                try
+                {
+                    return new Uri(value, UriKind.Absolute);
+                }
+                catch
+                {
+                    return null;
                 }
             }
         }

--- a/Src/SampQuery.cs
+++ b/Src/SampQuery.cs
@@ -397,7 +397,19 @@ namespace SAMPQuery
                                 }
                                 val = DateTime.Today.Add(parsedTime);
                             }
-                            else val = Convert.ChangeType(value, property.PropertyType, CultureInfo.InvariantCulture);
+                            else
+                            {
+                                try
+                                {
+                                    val = Convert.ChangeType(value, property.PropertyType, CultureInfo.InvariantCulture);
+                                }
+                                catch
+                                {
+                                    // the value could not be parsed, try to get a default.
+                                    value = "0";
+                                    val = Convert.ChangeType(value, property.PropertyType, CultureInfo.InvariantCulture);
+                                }
+                            }
 
                             property.SetValue(sampServerRulesData, val);
                         }

--- a/Src/SampQuery.cs
+++ b/Src/SampQuery.cs
@@ -387,38 +387,9 @@ namespace SAMPQuery
                         if (property != null)
                         {
                             if (property.PropertyType == typeof(bool)) val = value == "On";
-                            else if (property.PropertyType == typeof(Uri))
-                            {
-                                bool success = Uri.TryCreate(value, UriKind.Absolute, out Uri parsedUri);
-                                if (!success) 
-                                    success = Uri.TryCreate("http://" + value, UriKind.Absolute, out parsedUri);
-                                if (!success) 
-                                    parsedUri = new Uri("http://sa-mp.com/", UriKind.Absolute);
-
-                                val = parsedUri;
-                            }
-                            else if (property.PropertyType == typeof(DateTime))
-                            {
-                                bool success = TimeSpan.TryParse(value, out TimeSpan parsedTime);
-                                if (!success)
-                                {
-                                    parsedTime = TimeSpan.FromHours(0);
-                                }
-                                val = DateTime.Today.Add(parsedTime);
-                            }
-                            else
-                            {
-                                try
-                                {
-                                    val = Convert.ChangeType(value, property.PropertyType, CultureInfo.InvariantCulture);
-                                }
-                                catch
-                                {
-                                    // the value could not be parsed, try to get a default.
-                                    value = "0";
-                                    val = Convert.ChangeType(value, property.PropertyType, CultureInfo.InvariantCulture);
-                                }
-                            }
+                            else if (property.PropertyType == typeof(Uri)) val = Helpers.ParseWeburl(value);
+                            else if (property.PropertyType == typeof(DateTime)) val = Helpers.ParseTime(value);
+                            else val = Helpers.TryParseByte(value, property);
 
                             property.SetValue(sampServerRulesData, val);
                         }

--- a/Src/SampQuery.cs
+++ b/Src/SampQuery.cs
@@ -388,7 +388,19 @@ namespace SAMPQuery
                         {
                             if (property.PropertyType == typeof(bool)) val = value == "On";
                             else if (property.PropertyType == typeof(Uri)) val = new Uri("http://" + value, UriKind.Absolute);
-                            else if (property.PropertyType == typeof(DateTime)) val = DateTime.Today.Add(TimeSpan.Parse(value));
+                            else if (property.PropertyType == typeof(DateTime))
+                            {
+                                TimeSpan substracT;
+                                try
+                                {
+                                    substracT = TimeSpan.Parse(value);
+                                }
+                                catch
+                                {
+                                    substracT = TimeSpan.FromHours(0);
+                                }
+                                val = DateTime.Today.Add(substracT);
+                            }
                             else val = Convert.ChangeType(value, property.PropertyType, CultureInfo.InvariantCulture);
 
                             property.SetValue(sampServerRulesData, val);

--- a/Src/Utils/Helpers.cs
+++ b/Src/Utils/Helpers.cs
@@ -12,27 +12,5 @@ namespace SAMPQuery
             if (value.Length == 0)
                 throw new ArgumentException("Empty value not allowed", parameterName);
         }
-
-        public static Uri TryParseWeburl(string value)
-        {
-            try
-            {
-                // First try value alone, because some servers include http/s in their Weburl
-                return new Uri(value, UriKind.Absolute);
-            }
-            catch
-            {
-                try
-                {
-                    // If that fails, then try to parse with http
-                    return new Uri("http://" + value, UriKind.Absolute);
-                }
-                catch
-                {
-                    // If that fails, then just return sa-mp.com because we can't return nothing
-                    return new Uri("http://sa-mp.com/", UriKind.Absolute);
-                }
-            }
-        }
     }
 }

--- a/Src/Utils/Helpers.cs
+++ b/Src/Utils/Helpers.cs
@@ -1,4 +1,6 @@
 using System;
+using System.Globalization;
+using System.Reflection;
 
 namespace SAMPQuery 
 {
@@ -11,6 +13,43 @@ namespace SAMPQuery
         
             if (value.Length == 0)
                 throw new ArgumentException("Empty value not allowed", parameterName);
+        }
+
+        public static Uri ParseWeburl(string value)
+        {
+            if (Uri.TryCreate(value, UriKind.Absolute, out Uri parsedUri))
+            {
+                return parsedUri;
+            }
+            if (Uri.TryCreate(value, UriKind.Absolute, out parsedUri))
+            {
+                return parsedUri;
+            }
+            return new Uri("http://sa-mp.com/", UriKind.Absolute);
+        }
+
+        public static DateTime ParseTime(string value)
+        {
+            bool success = TimeSpan.TryParse(value, out TimeSpan parsedTime);
+            if (!success)
+            {
+                parsedTime = TimeSpan.FromHours(0);
+            }
+            return DateTime.Today.Add(parsedTime);
+        }
+
+        public static object TryParseByte(string value, PropertyInfo property)
+        {
+            try
+            {
+                return Convert.ChangeType(value, property.PropertyType, CultureInfo.InvariantCulture);
+            }
+            catch
+            {
+                // the value could not be parsed, try to return anything at all instead of crashing.
+                value = "0";
+                return Convert.ChangeType(value, property.PropertyType, CultureInfo.InvariantCulture);
+            }
         }
     }
 }

--- a/Src/Utils/Helpers.cs
+++ b/Src/Utils/Helpers.cs
@@ -12,5 +12,27 @@ namespace SAMPQuery
             if (value.Length == 0)
                 throw new ArgumentException("Empty value not allowed", parameterName);
         }
+
+        public static Uri TryParseWeburl(string value)
+        {
+            try
+            {
+                // First try value alone, because some servers include http/s in their Weburl
+                return new Uri(value, UriKind.Absolute);
+            }
+            catch
+            {
+                try
+                {
+                    // If that fails, then try to parse with http
+                    return new Uri("http://" + value, UriKind.Absolute);
+                }
+                catch
+                {
+                    // If that fails, then just return sa-mp.com because we can't return nothing
+                    return new Uri("http://sa-mp.com/", UriKind.Absolute);
+                }
+            }
+        }
     }
 }


### PR DESCRIPTION
<!--
  😀 Wonderful!  Thank you for opening a pull request for SAMPQuery.

  Please fill in the information below to expedite the review
  and (hopefully) merge of your change.

  If unsure about something.. just do as best as you're able,
  or contact me via email/linkedin/telegram.
-->

### Description of change
- Addresses issue in which invalid date strings (which are common in roleplay and cnr servers) cause an unhandled exception, by returning a time of 0 if the read time cannot be parsed. This is the best possible fix I think. It will return a false hour, but a lot better than failing the function completely. Fixes #10 
- Addresses issue where invalid Uris cause an unhandled exception if Weburl is invalid. It will try to use the entire value as the uri, and if that fails, it'll just return sa-mp.com as the Uri. This can mean returning an inaccurate Weburl, but again, better than failing the entire function.

NOTES:

- Tested locally on my computer after installing .NET 5 and the rules test worked fine.
- In my opinion, for future reference, I think the time should just be handled as a string instead of converting it to DateTime. In SA-MP times and dates seem to be mostly for show than for actual use. In fact, I'd strongly prefer this was the case, for what it's worth. But this is a personal preference and unrelated to the pull request at hand.

### Pull-Request Checklist

<!--
  Please make sure to review and check all of the following.

  If an item is not applicable, you can add "N/A" to the end.
-->

- [x] Code is up-to-date with the `master` branch
- [x] All tests are passed (if tests fail due to timeout, try running the tests later or run them sequentially)
- [x] This pull request links relevant issues as `Fixes #0000`
- [ ] There are new or updated unit tests validating the change - N/A
- [ ] Documentation (README.md) has been updated to reflect this change - N/A

<!--
  🎉 Thank you for contributing and making SAMPQuery even better!
-->
